### PR TITLE
Make YodaMerge tolerant for unfinished workflows

### DIFF
--- a/Law-Setup/generation/tasks/YodaMerge.py
+++ b/Law-Setup/generation/tasks/YodaMerge.py
@@ -156,8 +156,9 @@ class YodaMerge(Task):
         # localize the separate YODA files on grid storage
         inputfile_list = []
         for branch, target in self.input()['RunRivet']["collection"].targets.items():
-            with target.localize('r') as _file:
-                inputfile_list.append(_file.path)
+            if target.exists():
+                with target.localize('r') as _file:
+                    inputfile_list.append(_file.path)
 
         chunk_size = self.chunk_size
 


### PR DESCRIPTION
`YodaMerge` was not tolerating non-existing targets from its dependency, `RunRivet`. However, with the acceptance parameter it can be configured, that `RunRivet` and previous workflows allow returning status "success" without all its branches terminating successfully. With this fix, `YodaMerge` is able to run also on top of such workflows. 